### PR TITLE
Update: remove self closing tag from scroll down

### DIFF
--- a/src/front/Home/components/ScrollDown/ScrollDown.tsx
+++ b/src/front/Home/components/ScrollDown/ScrollDown.tsx
@@ -44,7 +44,7 @@ const box = css`
 export function ScrollDown() {
   return (
     <div className={scrollDownStyle}>
-      <div className={box} />
+      <div className={box}></div>
       <a href="#home--items">SCROLL DOWN</a>
     </div>
   );


### PR DESCRIPTION
## Problem

self closing tag will cause style bug due to `babel-plugin-lit-jsx`

## Solution

avoid from using self closing tag, but this is workaround